### PR TITLE
New CLI arguments and simplified signature of defining terms with locales only

### DIFF
--- a/bin/category-parser.js
+++ b/bin/category-parser.js
@@ -18,8 +18,9 @@ function rebuildDatabase( meta, errBuf ){
 			Object.keys( file ).forEach( function( termKey ){
 				var term = file[ termKey ];
 				meta.locales.forEach( function( lang ){
-					if ( !term.locales.hasOwnProperty( lang ) ) {
-						term.locales[ lang ] = '!-- PLACEHOLDER ADDED BY CHROME-I18N --!';
+					var locales = term.locales || term;
+					if ( !locales.hasOwnProperty( lang ) ) {
+						locales[ lang ] = '!-- PLACEHOLDER ADDED BY CHROME-I18N --!';
 						errBuf.push( 'Warning (locales): "' + lang +
 							'" version for "' + termKey +
 							'" is not defined' );
@@ -35,8 +36,8 @@ function rebuildDatabase( meta, errBuf ){
 	return db;
 } // rebuildDatabase()
 
-function parse( source, errBuf ) {
-	commons.resolveRelatives( source );
+function parse( source, errBuf, entryLocation ) {
+	commons.resolveRelatives( source, entryLocation );
 	return {
 		meta: source,
 		database: rebuildDatabase( source, errBuf )

--- a/bin/language-parser.js
+++ b/bin/language-parser.js
@@ -41,8 +41,8 @@ function rebuildDatabase( meta, errBuf ){
 	return db;
 } // rebuildDatabase()
 
-function parse( source, errBuf ) {
-	commons.resolveRelatives( source );
+function parse( source, errBuf, entryLocation ) {
+	commons.resolveRelatives( source, entryLocation );
 	return {
 		meta: source,
 		database: rebuildDatabase( source, errBuf )

--- a/bin/monolith-parser.js
+++ b/bin/monolith-parser.js
@@ -8,8 +8,8 @@
 
 var commons = require( '../lib/commons' );
 
-function parse( source ) {
-	commons.resolveRelatives( source.meta );
+function parse( source, errBuf, entryLocation ) {
+	commons.resolveRelatives( source.meta, entryLocation );
 	return source;
 } // parse()
 

--- a/lib/Dictionary.js
+++ b/lib/Dictionary.js
@@ -86,7 +86,7 @@ Dictionary.prototype = Object.defineProperties( {},
 							// this simulates a tuple
 							row = lang[ termKey ] = {};
 
-						row.message = term.locales[ langKey ];
+						row.message = (term.locales || term)[ langKey ];
 						if ( term.hasOwnProperty( 'description' ) ) {
 							row.description = term.description;
 						} // if

--- a/lib/commons.js
+++ b/lib/commons.js
@@ -124,24 +124,25 @@ function validateMeta( meta, errBuf ) {
  * fields.
  *
  * @param {object} meta the META object descriptor for the project
+ * @param {String} entryLocation absolute location of META file
  */
-function resolveRelatives( meta ) {
+function resolveRelatives( meta, entryLocation ) {
 	var solvers = {
 			string: function( relPath ){
 				// strings are always converted to array internally
 				if ( /[!*?]/.test( relPath ) ) {
 					// resolves for globs
-					return glob.sync( path.resolve( relPath ) );
+					return glob.sync( path.resolve( entryLocation, relPath ) );
 				} else {
 					if ( relPath.lastIndexOf( path.sep ) === relPath.length-1 ) {
 						// resolves for a path
-						return glob.sync( path.resolve( relPath + '*.json' ) );
+						return glob.sync( path.resolve( entryLocation, relPath + '*.json' ) );
 					} else {
 						// resolves for a filename
 						if ( path.extname( relPath ) ) {
-							return glob.sync( path.resolve( relPath ) );
+							return glob.sync( path.resolve( entryLocation, relPath ) );
 						} else {
-							return glob.sync( path.resolve( relPath + '.json' ) );
+							return glob.sync( path.resolve( entryLocation, relPath + '.json' ) );
 						} // if..else
 					} // if..else
 				} // if..else

--- a/lib/commons.js
+++ b/lib/commons.js
@@ -12,6 +12,13 @@ var // Load required modules
 	path = require( 'path' ),
 	glob = require( 'glob' );
 
+function endsWithSeparator( str ) {
+    var lastChar = str.charAt( str.length-1 );
+
+    return lastChar === '/' ||  // POSIX system
+		lastChar === '\\';      // Windows system
+}
+
 /**
  * Checks the integrity of the META descriptor.
  *
@@ -69,7 +76,7 @@ function validateMeta( meta, errBuf ) {
 					);
 					isImportsValid = false;
 				} else {
-					if ( meta.imports.lastIndexOf( path.sep ) !== meta.imports.length-1 ) {
+					if ( !endsWithSeparator( meta.imports ) ) {
 						errBuf.push( 'Error: (META): `imports` field is not a directory' );
 						isImportsValid = false;
 					} // if
@@ -83,7 +90,7 @@ function validateMeta( meta, errBuf ) {
 		errBuf.push( 'Error (META): `dest` field MUST be a string' );
 		isDestValid = false;
 	} else {
-		if ( meta.dest.lastIndexOf( path.sep ) !== meta.dest.length-1 ) {
+		if ( !endsWithSeparator( meta.dest ) ) {
 			errBuf.push( 'Error (META): `dest` is not a directory' );
 			isDestValid = false;
 		} // if
@@ -134,7 +141,7 @@ function resolveRelatives( meta, entryLocation ) {
 					// resolves for globs
 					return glob.sync( path.resolve( entryLocation, relPath ) );
 				} else {
-					if ( relPath.lastIndexOf( path.sep ) === relPath.length-1 ) {
+					if ( !endsWithSeparator(relPath) ) {
 						// resolves for a path
 						return glob.sync( path.resolve( entryLocation, relPath + '*.json' ) );
 					} else {


### PR DESCRIPTION
Draft proposal (no docs and tests written) for next features/changes:
1. New arguments:
- `-d`/`--dest`: The target directory for the _locales directory. Usually it is desired to define destination path directly through CLI (for instance, if one keeps destination path in some variable, and wants to use it for localization as well; plain JSON doesn't permit this). The path must end with a trailing path separator or the field will be invalid. Takes precedence over `dest` defined in dictionary or meta file.
- `-f`/`--force`: Forces writing dictionary even if locales already exist in destination path.
2. Old argument `-f`/`--file` renamed to `-e`/`--entry`.
3. New simplified signature of defining terms with locales only:
- Old way:
```json
"author": {
  "locales": {
    "en": "Author",
    "uk": "Автор"
  }
}
```
- New way:
```json
"author": {
  "en": "Author",
  "uk": "Автор"
}
```